### PR TITLE
Fix/trial list

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -86,6 +86,9 @@ const Nav = styled.nav`
 const App = () => {
   // state from upload file
   const [filenames, setFilenames] = useState([]);
+  const [formatedPatients, setformatedPatients] = useState([]);
+  const [filteredPatientsInfo, setfilteredPatientsInfo] = useState([]);
+
   return (
     <>
       <Router>
@@ -134,7 +137,18 @@ const App = () => {
                 />
               )}
             />
-            <Route path="/trial-list" component={TrialList} />
+            <Route
+              path="/trial-list"
+              render={props => (
+                <TrialList
+                  {...props}
+                  formatedPatients={formatedPatients}
+                  setformatedPatients={setformatedPatients}
+                  filteredPatientsInfo={filteredPatientsInfo}
+                  setfilteredPatientsInfo={setfilteredPatientsInfo}
+                />
+              )}
+            />
             <Route path="/match-trial" component={MatchTrial} />
             <Route path="/enter-patients" component={EnterPatients} />
             <Route component={NotFound} />

--- a/src/components/common/pdf/singleTrial/matchHeader.js
+++ b/src/components/common/pdf/singleTrial/matchHeader.js
@@ -57,7 +57,7 @@ const MatchHeader = ({ trialInfo, fileReference }) => {
         </View>
         <View style={rowContainer}>
           <Image style={icon} src={tickIcon} />
-          <Text style={text}>Recruiting: {OverallStatus}</Text>
+          <Text style={text}>Status: {OverallStatus}</Text>
         </View>
         <View style={rowContainer}>
           <Image style={icon} src={avatarIcon} />

--- a/src/components/pages/matchTrial/cardMatch.js
+++ b/src/components/pages/matchTrial/cardMatch.js
@@ -69,7 +69,7 @@ const matchCard = ({ trial, patientsInfo }) => {
             <div>
               <Tick />
             </div>
-            <span>{OverallStatus}</span>
+            <span>Status: {OverallStatus}</span>
           </FieldWrapper>
         </ColumnSection>
         <FieldWrapper>

--- a/src/components/pages/matchTrial/headerMatch.js
+++ b/src/components/pages/matchTrial/headerMatch.js
@@ -9,6 +9,7 @@ import {
   HighLightNumber,
   DetailSection,
   PrimaryParagraph,
+  HeaderItem,
 } from './style';
 
 import { colors } from '../../../styles/globalStyles';
@@ -38,12 +39,12 @@ const renderHeader = (matchedTrials, patientsInfo, size, fileReference) => {
         <HighLight>File name:</HighLight>
         <HighLightNumber>{fileReference}</HighLightNumber>
       </div>
-      <div>
+      <HeaderItem>
         <HighLight>Potentialy eligible trials:</HighLight>
         <HighLightNumber color={colors.confirm}>
           {potentiallyEligibleTrials}
         </HighLightNumber>
-      </div>
+      </HeaderItem>
       <DetailSection>
         <div>
           <HighLight>Nearly eligible Trials:</HighLight>

--- a/src/components/pages/matchTrial/index.js
+++ b/src/components/pages/matchTrial/index.js
@@ -56,7 +56,7 @@ export default class index extends Component {
     ) : (
       <>
         <BacklinkContainer>
-          <BackLink to="/">
+          <BackLink to="/trial-list">
             <Chevron width={20} />
           </BackLink>
         </BacklinkContainer>

--- a/src/components/pages/matchTrial/style.js
+++ b/src/components/pages/matchTrial/style.js
@@ -39,6 +39,10 @@ export const DetailSection = styled.div`
   }
 `;
 
+export const HeaderItem = styled.div`
+  margin: 1rem 0rem;
+`;
+
 export const HighLight = styled.span`
   color: ${colors.primary};
   text-decoration: underline;
@@ -59,6 +63,7 @@ export const PrimarySpam = styled.span`
 
 export const PrimaryParagraph = styled.p`
   color: ${colors.primary};
+  padding: 1rem 0rem;
 `;
 
 export const BoldParagraph = styled.p`
@@ -84,6 +89,7 @@ export const ExportButton = styled(PDFDownloadLink)`
   display: flex;
   justify-content: center;
   align-items: center;
+  margin-top: 0.5rem;
   :hover {
     color: white;
   }

--- a/src/components/pages/trialList/index.js
+++ b/src/components/pages/trialList/index.js
@@ -19,11 +19,7 @@ class TrialList extends Component {
   async componentDidMount() {
     const { history, location } = this.props;
     const { setformatedPatients, setfilteredPatientsInfo } = this.props;
-    if (this.props.filteredPatientsInfo[0]) {
-      return this.setState({
-        loading: false,
-      });
-    }
+
     if (location.state && location.state.length > 0) {
       const [patientsInfo] = location.state;
       if (Array.isArray(patientsInfo)) {
@@ -45,6 +41,10 @@ class TrialList extends Component {
           return message.error('something went wrong! please try again');
         }
       }
+    } else if (this.props.filteredPatientsInfo[0]) {
+      return this.setState({
+        loading: false,
+      });
     }
     return history.push('/');
   }

--- a/src/components/pages/trialList/index.js
+++ b/src/components/pages/trialList/index.js
@@ -13,14 +13,17 @@ const CardContainer = styled.div`
 class TrialList extends Component {
   state = {
     loading: true,
-    patientsInfo: [],
-    formatedPatients: [],
     // trialsArr: [], //if needed
   };
 
   async componentDidMount() {
     const { history, location } = this.props;
-
+    const { setformatedPatients, setfilteredPatientsInfo } = this.props;
+    if (this.props.filteredPatientsInfo[0]) {
+      return this.setState({
+        loading: false,
+      });
+    }
     if (location.state && location.state.length > 0) {
       const [patientsInfo] = location.state;
       if (Array.isArray(patientsInfo)) {
@@ -31,9 +34,10 @@ class TrialList extends Component {
             // trialsArr: originalTrialsArr,
           } = await getFilteredData(patientsInfo);
 
+          setfilteredPatientsInfo(filteredPatientsInfo);
+          setformatedPatients(formatedPatients);
+
           return this.setState({
-            patientsInfo: filteredPatientsInfo,
-            formatedPatients,
             loading: false,
             // trialsArr: originalTrialsArr,
           });
@@ -46,13 +50,17 @@ class TrialList extends Component {
   }
 
   sortList = value => {
-    const { patientsInfo } = this.state;
+    const {
+      filteredPatientsInfo: patientsInfo,
+      setfilteredPatientsInfo,
+    } = this.props;
     const sortedList = sortList(patientsInfo, value);
-    this.setState({ patientsInfo: sortedList });
+    setfilteredPatientsInfo(sortedList);
   };
 
   render() {
-    const { loading, patientsInfo, formatedPatients } = this.state;
+    const { loading } = this.state;
+    const { filteredPatientsInfo: patientsInfo, formatedPatients } = this.props;
     return loading ? (
       <Loading />
     ) : (


### PR DESCRIPTION
related #136 
### DONE
* Back button should go back to trials list not home page
* Hover over export button shouldn’t make text go black
* Remove PRONOUNCE from each trial rendered
* Add ‘Status:’ where we put in recruiting etc
* Add more spacing around Potentially Eligible Trials